### PR TITLE
Add custom taxonomy for the guiding principle

### DIFF
--- a/src/wordpress/wp-content/plugins/mobiles-wuppertal-leitbild/index.php
+++ b/src/wordpress/wp-content/plugins/mobiles-wuppertal-leitbild/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/src/wordpress/wp-content/plugins/mobiles-wuppertal-leitbild/mobiles-wuppertal-leitbild.php
+++ b/src/wordpress/wp-content/plugins/mobiles-wuppertal-leitbild/mobiles-wuppertal-leitbild.php
@@ -1,0 +1,37 @@
+<?php
+/*
+* Plugin Name: Mobiles Wuppertal: Leitbild
+* Description: Erweitert die WordPress-Taxonomie für das Leitbild von Mobiles Wuppertal.
+* Version: 1.0
+* Author: Arne Kamola
+* Author URI: https://arne.kamola.de/
+*/
+
+function mobileswupperatl_register_taxonomy_guidingprinciple() {
+	$labels = array(
+		'name'				=> _x( 'Leitbild', 'taxonomy general name' ),
+		'singular_name'		=> _x( 'Leitbild-Punkt', 'taxonomy singular name' ),
+		'search_items'		=> __( 'Leitbild durchsuchen' ),
+		'all_items'			=> __( 'Alle Leitbild-Punkte' ),
+		'parent_item'		=> __( 'Eltern Leitbild-Punkt' ),
+		'parent_item_colon'	=> __( 'Eltern Leitbild-Punkt:' ),
+		'edit_item'			=> __( 'Leitbild-Punkt bearbeiten' ),
+		'update_item'		=> __( 'Leitbild-Punkt aktualisieren' ),
+		'add_new_item'		=> __( 'Leitbild-Punkt hinzuügen' ),
+		'new_item_name'		=> __( 'Name des Leitbild-Punktes' ),
+		'menu_name'			=> __( 'Leitbild' ),
+	);
+	$args = array(
+		'hierarchical'		=> true, // make it hierarchical (like categories)
+		'labels'			=> $labels,
+		'show_ui'			=> true,
+		'show_admin_column'	=> true,
+		'query_var'			=> true,
+		'rewrite'			=> [ 'slug' => 'leitbild' ],
+	);
+	$object_types = array(
+		'post'
+	);
+	register_taxonomy( 'leitbild', $object_types, $args );
+}
+add_action( 'init', 'mobileswupperatl_register_taxonomy_guidingprinciple' );

--- a/src/wordpress/wp-content/themes/mobiles-wuppertal-2024/post.php
+++ b/src/wordpress/wp-content/themes/mobiles-wuppertal-2024/post.php
@@ -33,6 +33,21 @@
 		<?php the_content( __('Continue', 'wpblank') ); ?>
 	</div>
 
+	<?php
+		$guidingprinciples = get_the_terms( $post->ID, 'leitbild' );
+
+		if ( $guidingprinciples ):
+	?>
+		<aside class="guidingprinciples">
+			<h1>In unserem Leitbild</h1>
+			<ul>
+				<?php foreach ($guidingprinciples as $principle): ?>
+					<li><?php echo $principle->name; ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</aside>
+	<?php endif; ?>
+
 	<?php if ( has_tag() && is_singular() && !is_page() ): ?>
 		<footer class="meta tags">
 


### PR DESCRIPTION
Add the custom taxonomy as a WordPress plugin to follow the WordPress best practice to decouple content and design/theme.